### PR TITLE
Fix headers KeyError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 from setuptools import setup
 
-install_requires = ["h2>=2.2.0"]
+install_requires = ["h2>=2.2.0,<3.0.0"]
 if sys.version_info < (3, 5):
     install_requires.append("typing")
 


### PR DESCRIPTION
h2 3.0.0 introduced backward-Incompatible changes (see https://pypi.python.org/pypi/h2)

Fixes #16 

Quick fix. Need to change to the latest h2 version and make it work properly